### PR TITLE
install @jbrowse/cli, @gmod/jbrowse-cli looks not maintained

### DIFF
--- a/JBrowseDev/Dockerfile
+++ b/JBrowseDev/Dockerfile
@@ -6,13 +6,13 @@ USER root
 
 WORKDIR /var/www
 
-RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - \
   && yum install nodejs -y \
   && yum install git -y \
   && npm install -g yarn \
   && node --version && npm --version && yarn --version
 
-RUN npm install -g @gmod/jbrowse-cli \
+RUN npm install -g @jbrowse/cli \
   && jbrowse --version
 
 RUN git clone https://github.com/GMOD/jbrowse-components.git \

--- a/JBrowseDev/README.md
+++ b/JBrowseDev/README.md
@@ -9,7 +9,7 @@ To run the image:
 ```
 $ docker run -itd -p 8070:8080 -p 3000:3000 --name devJBrowse jbrowse2play:jbrowse-dev
 
-$ docker exec -it --workdir /var/www/jbrowse-components/packages/jbrowse-web devJBrowse yarn start
+$ docker exec -it --workdir /var/www/jbrowse-components/products/jbrowse-web devJBrowse yarn start
 ```
 
 You can now access the following locations in your browser:

--- a/JBrowseUse/Dockerfile
+++ b/JBrowseUse/Dockerfile
@@ -6,7 +6,7 @@ USER root
 
 WORKDIR /
 
-RUN npm install -g @gmod/jbrowse-cli \
+RUN npm install -g @jbrowse/cli \
   && jbrowse --version
 
 RUN jbrowse create jbrowse2

--- a/TripalJBrowseEmbed/Dockerfile
+++ b/TripalJBrowseEmbed/Dockerfile
@@ -6,11 +6,11 @@ MAINTAINER Lacey-Anne Sanderson <laceyannesanderson@gmail.com>
 
 WORKDIR /var/www/html/sites/all
 
-RUN curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash - \
+RUN curl -sL https://rpm.nodesource.com/setup_14.x | sudo bash - \
   && sudo yum install nodejs -y \
   && node --version && npm --version
 
-RUN npm install -g @gmod/jbrowse-cli \
+RUN npm install -g @jbrowse/cli \
   && jbrowse --version
 
 RUN mkdir tools && jbrowse create tools/jbrowse2


### PR DESCRIPTION
Fixes #1

Building the Docker images required to update the version of installed nodejs.

For the image _devJBrowse_ the _jbrowse-web_ folder was in a different folder given in the readme file.
